### PR TITLE
Generation by convention

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,9 +60,20 @@
             <version>3.3.2</version>
         </dependency>
         <dependency>
+            <groupId>io.github.lukehutch</groupId>
+            <artifactId>fast-classpath-scanner</artifactId>
+            <version>1.99.0</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-junit</artifactId>
+            <version>2.0.0.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.io-informatics.oss</groupId>
     <artifactId>jackson-jsonld</artifactId>
-    <version>0.0.6-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <name>jackson-jsonld</name>
     <description>JSON-LD Module for Jackson</description>
     <url>https://github.com/io-informatics/jackson-jsonld</url>

--- a/pom.xml
+++ b/pom.xml
@@ -55,9 +55,9 @@
             <version>${version.jsonld.java}</version>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.3.2</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/ioinformarics/oss/jackson/module/jsonld/HydraCollection.java
+++ b/src/main/java/ioinformarics/oss/jackson/module/jsonld/HydraCollection.java
@@ -9,11 +9,11 @@ import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldProperty;
  */
 public class HydraCollection extends BeanJsonldResource {
 
-    HydraCollection(Iterable<JsonldResource> graph, JsonNode context, String type, String id) {
+    HydraCollection(Iterable<?> graph, JsonNode context, String type, String id) {
         super(new CollectionContainer(graph), context, type, id);
     }
 
-    HydraCollection(Iterable<JsonldResource> graph,
+    HydraCollection(Iterable<?> graph,
                     JsonNode context,
                     String type,
                     String id,

--- a/src/main/java/ioinformarics/oss/jackson/module/jsonld/HydraCollectionBuilder.java
+++ b/src/main/java/ioinformarics/oss/jackson/module/jsonld/HydraCollectionBuilder.java
@@ -59,7 +59,7 @@ public class HydraCollectionBuilder<T> extends JsonldGraphBuilder<T> {
     }
 
     public JsonldResource build(Iterable<T> elements) {
-        return new HydraCollection(buildElements(elements), buildContext(elements).orElse(null),
+        return new HydraCollection(elements, buildContext(elements).orElse(null),
                 isPaged? "hydra:PagedCollection": "hydra:Collection", graphId, totalItems, itemsPerPage, firstPage, nextPage, previousPage, lastPage);
     }
 

--- a/src/main/java/ioinformarics/oss/jackson/module/jsonld/JsonldContextFactory.java
+++ b/src/main/java/ioinformarics/oss/jackson/module/jsonld/JsonldContextFactory.java
@@ -5,15 +5,15 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldId;
 import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldLink;
 import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldNamespace;
 import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldProperty;
-
+import org.apache.commons.lang3.ClassUtils;
 import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import java.lang.reflect.ParameterizedType;
+import java.util.*;
+import java.util.stream.Stream;
 
 /**
  * @author Alexander De Leon
@@ -34,7 +34,7 @@ public class JsonldContextFactory {
         ObjectNode generatedContext = JsonNodeFactory.withExactBigDecimals(true).objectNode();
         generateNamespaces(objType).forEach((name, uri) -> generatedContext.set(name, new TextNode(uri)));
         //TODO: This is bad...it does not consider other Jackson annotations. Need to use a AnnotationIntrospector?
-        final Map<String, TextNode> fieldContexts = generateContextsForFields(objType);
+        final Map<String, JsonNode> fieldContexts = generateContextsForFields(objType);
         fieldContexts.forEach(generatedContext::set);
         //add links
         JsonldLink[] links = objType.getAnnotationsByType(JsonldLink.class);
@@ -51,25 +51,58 @@ public class JsonldContextFactory {
         return generatedContext.size() != 0 ? Optional.of(generatedContext) : Optional.empty();
     }
 
-    private static Map<String, TextNode> generateContextsForFields(Class<?> objType) {
-        final Map<String, TextNode> contexts = new HashMap<>();
+    private static Map<String, JsonNode> generateContextsForFields(Class<?> objType) {
+        final Map<String, JsonNode> contexts = new HashMap<>();
         Class<?> currentClass = objType;
+        Optional<JsonldNamespace> namespace = Optional.ofNullable(currentClass.getAnnotation(JsonldNamespace.class));
         while (currentClass != null && !currentClass.equals(Object.class)) {
-            Optional<JsonldNamespace> namespace = Optional.ofNullable(currentClass.getAnnotation(JsonldNamespace.class));
             final Field[] fields = currentClass.getDeclaredFields();
             for (Field f : fields) {
                 final JsonldProperty jsonldProperty = f.getAnnotation(JsonldProperty.class);
+                Optional<String> propertyId = Optional.empty();
                 // Most concrete field overrides any field with the same name defined higher up the hierarchy
                 if (jsonldProperty != null && !contexts.containsKey(f.getName())) {
-                    contexts.put(f.getName(), TextNode.valueOf(jsonldProperty.value()));
+                    propertyId = Optional.of(jsonldProperty.value());
                 }
                 else if(jsonldProperty == null && namespace.map(JsonldNamespace::applyToProperties).orElse(false)) {
-                    contexts.put(f.getName(), TextNode.valueOf(namespace.get().name() + ":" + f.getName()));
+                    propertyId = Optional.of(namespace.get().name() + ":" + f.getName());
                 }
+                propertyId.ifPresent((id) -> {
+                    if(isRelation(f)) {
+                        ObjectNode node = JsonNodeFactory.withExactBigDecimals(true).objectNode();
+                        node.set("@id", TextNode.valueOf(id));
+                        node.set("@type", TextNode.valueOf("@id"));
+                        contexts.put(f.getName(), node);
+                    }
+                    else {
+                        contexts.put(f.getName(), TextNode.valueOf(id));
+                    }
+                });
             }
             currentClass = currentClass.getSuperclass();
+            if(!namespace.isPresent()) {
+                namespace = Optional.ofNullable(currentClass.getAnnotation(JsonldNamespace.class));
+            }
         }
         return contexts;
+    }
+
+    private static boolean isRelation(Field field) {
+        Class<?> type = field.getType();
+        if(Collection.class.isAssignableFrom(type)) {
+            ParameterizedType parameterizedType = (ParameterizedType) field.getGenericType();
+            type = (Class<?>) parameterizedType.getActualTypeArguments()[0];
+        }
+        if(type.isArray()) {
+            type = type.getComponentType();
+        }
+        return Stream.concat(Stream.of(type),
+                Stream.concat(ClassUtils.getAllSuperclasses(type).stream(), ClassUtils.getAllInterfaces(type).stream()))
+                .flatMap(currentClass -> Stream.concat(
+                        Stream.of(currentClass.getDeclaredFields()),
+                        Stream.of(currentClass.getDeclaredMethods())
+                ))
+                .anyMatch(p -> p.getAnnotation(JsonldId.class) != null);
     }
 
     private static Map<String, String> generateNamespaces(Class<?> objType) {

--- a/src/main/java/ioinformarics/oss/jackson/module/jsonld/JsonldGraph.java
+++ b/src/main/java/ioinformarics/oss/jackson/module/jsonld/JsonldGraph.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 public class JsonldGraph extends BeanJsonldResource {
 
 
-    JsonldGraph(Iterable<JsonldResource> graph, JsonNode context, String type, String id) {
+    JsonldGraph(Iterable<?> graph, JsonNode context, String type, String id) {
         super(new JsonldGraphContainer(graph), context, type, id);
     }
 

--- a/src/main/java/ioinformarics/oss/jackson/module/jsonld/JsonldGraphBuilder.java
+++ b/src/main/java/ioinformarics/oss/jackson/module/jsonld/JsonldGraphBuilder.java
@@ -1,8 +1,10 @@
 package ioinformarics.oss.jackson.module.jsonld;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -46,9 +48,12 @@ public class JsonldGraphBuilder<T> {
         return this;
     }
 
+    public JsonldResource build(T ... elements) {
+        return build(Arrays.asList(elements));
+    }
+
     public JsonldResource build(Iterable<T> elements) {
-        Optional<JsonNode> generatedContext = JsonldContextFactory.multiContext(Optional.ofNullable(context), JsonldContextFactory.fromAnnotations(elements));
-        return new JsonldGraph(buildElements(elements), generatedContext.orElse(null), graphType, graphId);
+        return new JsonldGraph(elements, Optional.ofNullable(context).map(c -> TextNode.valueOf(c)).orElse(null), graphType, graphId);
 
     }
 
@@ -56,17 +61,6 @@ public class JsonldGraphBuilder<T> {
         return typeSupplier.apply(e);
     }
 
-    protected Iterable<JsonldResource> buildElements(Iterable<T> elements) {
-        ArrayList<JsonldResource> list = new ArrayList<>();
-        elements.forEach(e -> {
-            JsonldResourceBuilder builder = JsonldResource.Builder.create();
-            builder.type(resourceBuilder.getType(e));
-            builder.id(resourceBuilder.getId(e));
-            builder.context(null);
-            list.add(builder.build(e));
-        });
-        return list;
-    }
 
 
 }

--- a/src/main/java/ioinformarics/oss/jackson/module/jsonld/JsonldGraphBuilder.java
+++ b/src/main/java/ioinformarics/oss/jackson/module/jsonld/JsonldGraphBuilder.java
@@ -1,10 +1,6 @@
 package ioinformarics.oss.jackson.module.jsonld;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
-import org.apache.commons.lang.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Optional;

--- a/src/main/java/ioinformarics/oss/jackson/module/jsonld/JsonldResourceBuilder.java
+++ b/src/main/java/ioinformarics/oss/jackson/module/jsonld/JsonldResourceBuilder.java
@@ -2,6 +2,8 @@ package ioinformarics.oss.jackson.module.jsonld;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldType;
+import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldTypeFromJavaClass;
+import ioinformarics.oss.jackson.module.jsonld.internal.AnnotationConstants;
 
 import java.util.Map;
 import java.util.Optional;
@@ -63,8 +65,22 @@ public class JsonldResourceBuilder<T> {
     }
 
     static String dynamicTypeLookup(Class<?> objType){
-        JsonldType type = objType.getAnnotation(JsonldType.class);
-        return type == null? null : type.value();
+        return Optional.ofNullable(objType.getAnnotation(JsonldType.class))
+                .map(JsonldType::value)
+                .orElse(typeFromJavaClass(objType));
+    }
+
+    static String typeFromJavaClass(Class<?> objType) {
+        return Optional.ofNullable(objType.getAnnotation(JsonldTypeFromJavaClass.class))
+                .map((t) -> {
+                    String prefix = t.namespace();
+                    if(prefix.equals(AnnotationConstants.UNASSIGNED)) {
+                        prefix = t.namespacePrefix().equals(AnnotationConstants.UNASSIGNED) ? "" : t.namespacePrefix() + ":";
+                    }
+                    return prefix + objType.getSimpleName();
+
+                })
+                .orElse(null);
     }
 
 }

--- a/src/main/java/ioinformarics/oss/jackson/module/jsonld/annotation/JsonldNamespace.java
+++ b/src/main/java/ioinformarics/oss/jackson/module/jsonld/annotation/JsonldNamespace.java
@@ -1,0 +1,15 @@
+package ioinformarics.oss.jackson.module.jsonld.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * @author Alexander De Leon (alex.deleon@devialab.com)
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface JsonldNamespace {
+    String name();
+    String uri();
+    boolean applyToProperties() default true;
+}

--- a/src/main/java/ioinformarics/oss/jackson/module/jsonld/annotation/JsonldResource.java
+++ b/src/main/java/ioinformarics/oss/jackson/module/jsonld/annotation/JsonldResource.java
@@ -1,15 +1,12 @@
 package ioinformarics.oss.jackson.module.jsonld.annotation;
 
-
 import java.lang.annotation.*;
 
 /**
- * @author Alexander De Leon
+ * @author Alexander De Leon (alex.deleon@devialab.com)
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Inherited
-@JsonldResource
-public @interface JsonldType {
-    String value();
+public @interface JsonldResource {
 }

--- a/src/main/java/ioinformarics/oss/jackson/module/jsonld/annotation/JsonldType.java
+++ b/src/main/java/ioinformarics/oss/jackson/module/jsonld/annotation/JsonldType.java
@@ -1,5 +1,6 @@
 package ioinformarics.oss.jackson.module.jsonld.annotation;
 
+
 import java.lang.annotation.*;
 
 /**

--- a/src/main/java/ioinformarics/oss/jackson/module/jsonld/annotation/JsonldTypeFromJavaClass.java
+++ b/src/main/java/ioinformarics/oss/jackson/module/jsonld/annotation/JsonldTypeFromJavaClass.java
@@ -10,6 +10,7 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Inherited
+@JsonldResource
 public @interface JsonldTypeFromJavaClass {
     String namespace() default AnnotationConstants.UNASSIGNED;
     String namespacePrefix() default AnnotationConstants.UNASSIGNED;

--- a/src/main/java/ioinformarics/oss/jackson/module/jsonld/annotation/JsonldTypeFromJavaClass.java
+++ b/src/main/java/ioinformarics/oss/jackson/module/jsonld/annotation/JsonldTypeFromJavaClass.java
@@ -1,0 +1,16 @@
+package ioinformarics.oss.jackson.module.jsonld.annotation;
+
+import ioinformarics.oss.jackson.module.jsonld.internal.AnnotationConstants;
+
+import java.lang.annotation.*;
+
+/**
+ * @author Alexander De Leon (alex.deleon@devialab.com)
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface JsonldTypeFromJavaClass {
+    String namespace() default AnnotationConstants.UNASSIGNED;
+    String namespacePrefix() default AnnotationConstants.UNASSIGNED;
+}

--- a/src/main/java/ioinformarics/oss/jackson/module/jsonld/internal/AnnotationConstants.java
+++ b/src/main/java/ioinformarics/oss/jackson/module/jsonld/internal/AnnotationConstants.java
@@ -1,0 +1,8 @@
+package ioinformarics.oss.jackson.module.jsonld.internal;
+
+/**
+ * @author Alexander De Leon (alex.deleon@devialab.com)
+ */
+public interface AnnotationConstants {
+    String UNASSIGNED = "[unassigned]";
+}

--- a/src/main/java/ioinformarics/oss/jackson/module/jsonld/internal/JsonldBeanDeserializerModifier.java
+++ b/src/main/java/ioinformarics/oss/jackson/module/jsonld/internal/JsonldBeanDeserializerModifier.java
@@ -7,18 +7,15 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
 import com.fasterxml.jackson.databind.deser.std.DelegatingDeserializer;
-import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
 import com.github.jsonldjava.core.JsonLdError;
 import com.github.jsonldjava.core.JsonLdOptions;
 import com.github.jsonldjava.core.JsonLdProcessor;
-import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldProperty;
 import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldType;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 /**
  * @author Alexander De Leon

--- a/src/main/java/ioinformarics/oss/jackson/module/jsonld/internal/JsonldResourceSerializer.java
+++ b/src/main/java/ioinformarics/oss/jackson/module/jsonld/internal/JsonldResourceSerializer.java
@@ -1,0 +1,59 @@
+package ioinformarics.oss.jackson.module.jsonld.internal;
+
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.ser.BeanSerializer;
+import com.fasterxml.jackson.databind.ser.std.BeanSerializerBase;
+import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldLink;
+import ioinformarics.oss.jackson.module.jsonld.util.JsonldResourceUtils;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.util.*;
+
+/**
+ * @author Alexander De Leon (alex.deleon@devialab.com)
+ */
+public class JsonldResourceSerializer extends BeanSerializer {
+
+    public JsonldResourceSerializer(BeanSerializerBase src) {
+        super(src);
+    }
+
+    @Override
+    protected void serializeFields(Object bean, JsonGenerator jgen, SerializerProvider provider) throws IOException, JsonGenerationException {
+        Optional<String> type = JsonldResourceUtils.dynamicTypeLookup(bean.getClass());
+        if(type.isPresent()) {
+            jgen.writeStringField("@type", type.get());
+        }
+        Optional<ObjectNode> context = JsonldResourceUtils.getContext(bean);
+        if(context.isPresent()) {
+            jgen.writeObjectField("@context", context.get());
+        }
+        super.serializeFields(bean, jgen, provider);
+        getLinks(bean).ifPresent(linksMap ->
+                linksMap.forEach((key, value) -> {
+                    try {
+                        jgen.writeStringField(key, value);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }));
+    }
+
+    protected Optional<Map<String,String>> getLinks(Object resource) {
+        Map<String,String> linksNodes = null;
+        Class<?> beanType = resource.getClass();
+        JsonldLink[] links = beanType.getAnnotationsByType(JsonldLink.class);
+        if(links != null){
+            linksNodes = new HashMap<>(links.length);
+            for(int i=0; i < links.length; i++){
+                linksNodes.put(links[i].name(), links[i].href());
+            }
+        }
+        return Optional.ofNullable(linksNodes);
+    }
+
+}

--- a/src/main/java/ioinformarics/oss/jackson/module/jsonld/internal/JsonldResourceSerializerModifier.java
+++ b/src/main/java/ioinformarics/oss/jackson/module/jsonld/internal/JsonldResourceSerializerModifier.java
@@ -1,24 +1,10 @@
 package ioinformarics.oss.jackson.module.jsonld.internal;
 
-import com.fasterxml.jackson.core.JsonGenerationException;
-import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.*;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
-import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
-import com.fasterxml.jackson.databind.ser.BeanSerializer;
-import com.fasterxml.jackson.databind.ser.BeanSerializerBuilder;
 import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
-import com.fasterxml.jackson.databind.ser.impl.ObjectIdWriter;
 import com.fasterxml.jackson.databind.ser.std.BeanSerializerBase;
-import com.fasterxml.jackson.databind.ser.std.StdDelegatingSerializer;
-import ioinformarics.oss.jackson.module.jsonld.BeanJsonldResource;
-import ioinformarics.oss.jackson.module.jsonld.JsonldResource;
-import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldLink;
-
-import java.io.IOException;
-import java.util.*;
+import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldResource;
+import ioinformarics.oss.jackson.module.jsonld.util.AnnotationsUtils;
 
 /**
  * @author Alexander De Leon
@@ -28,35 +14,11 @@ public class JsonldResourceSerializerModifier extends BeanSerializerModifier {
 
     @Override
     public JsonSerializer<?> modifySerializer(SerializationConfig config, BeanDescription beanDesc, JsonSerializer<?> serializer) {
-        if(BeanJsonldResource.class.isAssignableFrom(beanDesc.getBeanClass()) && serializer instanceof BeanSerializerBase){
-            return new BeanSerializer((BeanSerializerBase) serializer) {
-                @Override
-                protected void serializeFields(Object bean, JsonGenerator jgen, SerializerProvider provider) throws IOException, JsonGenerationException {
-                    super.serializeFields(bean, jgen, provider);
-                    getLinks((BeanJsonldResource)bean).ifPresent(linksMap ->
-                            linksMap.forEach((key, value) -> {
-                                try {
-                                    jgen.writeFieldName(key);
-                                    jgen.writeString(value);
-                                } catch (Exception e) {
-                                }
-                            }));
-                }
-            };
+        if(AnnotationsUtils.isAnnotationPresent(beanDesc.getBeanClass(), JsonldResource.class) && serializer instanceof BeanSerializerBase){
+            return new JsonldResourceSerializer((BeanSerializerBase) serializer);
         }
         return serializer;
     }
 
-    protected Optional<Map<String,String>> getLinks(BeanJsonldResource resource) {
-        Map<String,String> linksNodes = null;
-        Class<?> beanType = resource.scopedObj.getClass();
-        JsonldLink[] links = beanType.getAnnotationsByType(JsonldLink.class);
-        if(links != null){
-            linksNodes = new HashMap<>(links.length);
-            for(int i=0; i < links.length; i++){
-                linksNodes.put(links[i].name(), links[i].href());
-            }
-        }
-        return Optional.ofNullable(linksNodes);
-    }
+
 }

--- a/src/main/java/ioinformarics/oss/jackson/module/jsonld/util/AnnotationsUtils.java
+++ b/src/main/java/ioinformarics/oss/jackson/module/jsonld/util/AnnotationsUtils.java
@@ -1,0 +1,34 @@
+package ioinformarics.oss.jackson.module.jsonld.util;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Alexander De Leon (alex.deleon@devialab.com)
+ */
+public abstract class AnnotationsUtils {
+
+    public static boolean isAnnotationPresent(Class<?> type, Class<? extends Annotation> annotationType) {
+        return isAnnotationPresent(type, annotationType, new ArrayList<>());
+    }
+
+    protected static boolean isAnnotationPresent(Class<?> type, Class<? extends Annotation> annotationType, List<Class<?>> ignore) {
+        if(type.isAnnotationPresent(annotationType)) {
+            return true;
+        }
+        if(type.getAnnotations().length == 0) {
+            return false;
+        }
+        for(Annotation a : type.getAnnotations()) {
+            if(!ignore.contains(a.annotationType())) {
+                ignore.add(type);
+                if(isAnnotationPresent(a.annotationType(), annotationType, ignore)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/ioinformarics/oss/jackson/module/jsonld/util/JsonUtils.java
+++ b/src/main/java/ioinformarics/oss/jackson/module/jsonld/util/JsonUtils.java
@@ -1,0 +1,36 @@
+package ioinformarics.oss.jackson.module.jsonld.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.util.Iterator;
+
+/**
+ * @author Alexander De Leon (alex.deleon@devialab.com)
+ */
+public abstract class JsonUtils {
+
+    public static JsonNode merge(JsonNode mainNode, JsonNode updateNode) {
+
+        Iterator<String> fieldNames = updateNode.fieldNames();
+        while (fieldNames.hasNext()) {
+
+            String fieldName = fieldNames.next();
+            JsonNode jsonNode = mainNode.get(fieldName);
+            // if field exists and is an embedded object
+            if (jsonNode != null && jsonNode.isObject()) {
+                merge(jsonNode, updateNode.get(fieldName));
+            }
+            else {
+                if (mainNode instanceof ObjectNode) {
+                    // Overwrite field
+                    JsonNode value = updateNode.get(fieldName);
+                    ((ObjectNode) mainNode).set(fieldName, value);
+                }
+            }
+
+        }
+
+        return mainNode;
+    }
+}

--- a/src/main/java/ioinformarics/oss/jackson/module/jsonld/util/JsonldResourceUtils.java
+++ b/src/main/java/ioinformarics/oss/jackson/module/jsonld/util/JsonldResourceUtils.java
@@ -1,0 +1,37 @@
+package ioinformarics.oss.jackson.module.jsonld.util;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import ioinformarics.oss.jackson.module.jsonld.JsonldContextFactory;
+import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldType;
+import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldTypeFromJavaClass;
+import ioinformarics.oss.jackson.module.jsonld.internal.AnnotationConstants;
+
+import java.util.Optional;
+
+/**
+ * @author Alexander De Leon (alex.deleon@devialab.com)
+ */
+public abstract class JsonldResourceUtils {
+
+    public static Optional<ObjectNode> getContext(Object scopedObj) {
+        return JsonldContextFactory.fromAnnotations(scopedObj);
+    }
+
+    public static Optional<String> dynamicTypeLookup(Class<?> objType){
+        Optional<String> typeFromAnnotation = Optional.ofNullable(objType.getAnnotation(JsonldType.class))
+                    .map(JsonldType::value);
+        return typeFromAnnotation.isPresent() ? typeFromAnnotation : typeFromJavaClass(objType);
+    }
+
+    private static Optional<String> typeFromJavaClass(Class<?> objType) {
+        return Optional.ofNullable(objType.getAnnotation(JsonldTypeFromJavaClass.class))
+                .map((t) -> {
+                    String prefix = t.namespace();
+                    if(prefix.equals(AnnotationConstants.UNASSIGNED)) {
+                        prefix = t.namespacePrefix().equals(AnnotationConstants.UNASSIGNED) ? "" : t.namespacePrefix() + ":";
+                    }
+                    return prefix + objType.getSimpleName();
+
+                });
+    }
+}

--- a/src/test/java/ioinformarics/oss/jackson/module/jsonld/JsonldContextFactoryTest.java
+++ b/src/test/java/ioinformarics/oss/jackson/module/jsonld/JsonldContextFactoryTest.java
@@ -1,15 +1,14 @@
 package ioinformarics.oss.jackson.module.jsonld;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldId;
-import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldProperty;
-import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldType;
+import com.fasterxml.jackson.databind.node.TextNode;
+import ioinformarics.oss.jackson.module.jsonld.testobjects.Child;
+import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.*;
 import org.junit.Test;
 
 import java.util.*;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class JsonldContextFactoryTest {
 
@@ -29,23 +28,16 @@ public class JsonldContextFactoryTest {
         assertEquals(fieldNames.size(), counter);
     }
 
-    @JsonldType("http://example.com/schema#Parent")
-    public static class Parent {
-
-        @JsonldId
-        Integer id;
-
-        @JsonldProperty("http://www.w3.org/2000/01/rdf-schema#label")
-        String name;
+    @Test
+    public void testContextForPackage() {
+        ObjectNode context = JsonldContextFactory.fromPackage("ioinformarics.oss.jackson.module.jsonld.testobjects");
+        System.out.println("Context: "+context);
+        ObjectNode innerContext = (ObjectNode) context.get("@context");
+        assertNotNull(innerContext);
+        // from: ioinformarics.oss.jackson.module.jsonld.testobjects.Parent
+        assertThat(innerContext.get("name"), is(TextNode.valueOf("http://www.w3.org/2000/01/rdf-schema#label")));
+        // from: ioinformarics.oss.jackson.module.jsonld.testobjects.internal.TestObject
+        assertThat(innerContext.get("url"), is(TextNode.valueOf("http://schema.org/url")));
     }
 
-    @JsonldType("http://example.com/schema#Child")
-    public static class Child extends Parent {
-
-        @JsonldProperty("http://www.w3.org/2000/01/rdf-schema#comment")
-        String description;
-
-        @JsonldProperty("http://example.com/schema#version")
-        Long version;
-    }
 }

--- a/src/test/java/ioinformarics/oss/jackson/module/jsonld/JsonldContextFactoryTest.java
+++ b/src/test/java/ioinformarics/oss/jackson/module/jsonld/JsonldContextFactoryTest.java
@@ -29,7 +29,7 @@ public class JsonldContextFactoryTest {
     }
 
     @Test
-    public void testContextForPackage() {
+    public void testContextFromPackage() {
         ObjectNode context = JsonldContextFactory.fromPackage("ioinformarics.oss.jackson.module.jsonld.testobjects");
         System.out.println("Context: "+context);
         ObjectNode innerContext = (ObjectNode) context.get("@context");

--- a/src/test/java/ioinformarics/oss/jackson/module/jsonld/JsonldModuleTest.java
+++ b/src/test/java/ioinformarics/oss/jackson/module/jsonld/JsonldModuleTest.java
@@ -3,6 +3,7 @@ package ioinformarics.oss.jackson.module.jsonld;
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldId;
+import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldNamespace;
 import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldProperty;
 import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldType;
 import org.junit.Test;
@@ -33,7 +34,8 @@ public class JsonldModuleTest {
     }
 
 
-    @JsonldType("http://schema.org/Person")
+    @JsonldNamespace(name = "s", uri = "http://schema.org/")
+    @JsonldType("s:Person")
     public class Person {
         @JsonldId
         public  String id;

--- a/src/test/java/ioinformarics/oss/jackson/module/jsonld/JsonldModuleTest.java
+++ b/src/test/java/ioinformarics/oss/jackson/module/jsonld/JsonldModuleTest.java
@@ -27,9 +27,7 @@ public class JsonldModuleTest {
         alex.jobtitle = "Software Developer";
         alex.url = "http://alexdeleon.name";
 
-        JsonldResourceBuilder builder = JsonldResource.Builder.create();
-        builder.context("http://json-ld.org/contexts/person.jsonld");
-        objectMapper.writer().writeValue(System.out, builder.build(alex));
+        objectMapper.writer().writeValue(System.out, alex);
 
     }
 

--- a/src/test/java/ioinformarics/oss/jackson/module/jsonld/JsonldModuleTest.java
+++ b/src/test/java/ioinformarics/oss/jackson/module/jsonld/JsonldModuleTest.java
@@ -31,6 +31,23 @@ public class JsonldModuleTest {
 
     }
 
+    @Test
+    public void testSerializeGraph() throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JsonldModule());
+
+        Person alex = new Person();
+        alex.id = "mailto:me@alexdeleon.name";
+        alex.name = "Alex De Leon";
+        alex.jobtitle = "Software Developer";
+        alex.url = "http://alexdeleon.name";
+
+        Object graph = JsonldGraph.Builder.create().id("http://example.graph").build(alex);
+
+        objectMapper.writer().writeValue(System.out, graph);
+
+    }
+
 
     @JsonldNamespace(name = "s", uri = "http://schema.org/")
     @JsonldType("s:Person")

--- a/src/test/java/ioinformarics/oss/jackson/module/jsonld/testobjects/Child.java
+++ b/src/test/java/ioinformarics/oss/jackson/module/jsonld/testobjects/Child.java
@@ -1,0 +1,17 @@
+package ioinformarics.oss.jackson.module.jsonld.testobjects;
+
+import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldProperty;
+import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldType;
+
+/**
+ * @author Alexander De Leon (alex.deleon@devialab.com)
+ */
+@JsonldType("http://example.com/schema#Child")
+public class Child extends Parent {
+
+    @JsonldProperty("http://www.w3.org/2000/01/rdf-schema#comment")
+    String description;
+
+    @JsonldProperty("http://example.com/schema#version")
+    Long version;
+}

--- a/src/test/java/ioinformarics/oss/jackson/module/jsonld/testobjects/Parent.java
+++ b/src/test/java/ioinformarics/oss/jackson/module/jsonld/testobjects/Parent.java
@@ -1,0 +1,18 @@
+package ioinformarics.oss.jackson.module.jsonld.testobjects;
+
+import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldId;
+import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldProperty;
+import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldType;
+
+/**
+ * @author Alexander De Leon (alex.deleon@devialab.com)
+ */
+@JsonldType("http://example.com/schema#Parent")
+public class Parent {
+
+    @JsonldId
+    Integer id;
+
+    @JsonldProperty("http://www.w3.org/2000/01/rdf-schema#label")
+    String name;
+}

--- a/src/test/java/ioinformarics/oss/jackson/module/jsonld/testobjects/internal/TestObject.java
+++ b/src/test/java/ioinformarics/oss/jackson/module/jsonld/testobjects/internal/TestObject.java
@@ -1,0 +1,21 @@
+package ioinformarics.oss.jackson.module.jsonld.testobjects.internal;
+
+import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldId;
+import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldProperty;
+import ioinformarics.oss.jackson.module.jsonld.annotation.JsonldResource;
+
+/**
+ * @author Alexander De Leon (alex.deleon@devialab.com)
+ */
+@JsonldResource
+public class TestObject {
+
+    @JsonldId
+    public String id;
+
+    @JsonldProperty("http://schema.org/url")
+    public String url;
+
+    @JsonldProperty("http://www.w3.org/2000/01/rdf-schema#label")
+    String name;
+}


### PR DESCRIPTION
This enables direct serialization of complete object graph structures with the need to create explicit `JsonldResource` instances and without needing much annotations.